### PR TITLE
Load xml using file name instead of stream (avoid file lock).

### DIFF
--- a/src/DotnetVersion/DotnetVersion.csproj
+++ b/src/DotnetVersion/DotnetVersion.csproj
@@ -2,10 +2,11 @@
   <PropertyGroup>
     <OutputType>Exe</OutputType>
     <TargetFramework>netcoreapp2.1</TargetFramework>
-    <Version>1.4.0</Version>
+    <Version>1.5.0</Version>
     <PackageId>DotnetVersion</PackageId>
     <Authors>jon-indico</Authors>
     <Company>Indico Systems AS</Company>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackAsTool>true</PackAsTool>
     <ToolCommandName>dotnet-version</ToolCommandName>
     <Description>Update project version, through an easy API.</Description>


### PR DESCRIPTION
Hello, this PR is to resolve the issue I logged earlier today.  Just opens the x doc using file name instead of stream.  With this change I no longer get the IO exception noted in the issue.